### PR TITLE
Recreated test for the issue https://github.com/eclipse/xtext/issues/2920

### DIFF
--- a/org.eclipse.xtext.builder.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.xtext.builder.tests/META-INF/MANIFEST.MF
@@ -40,7 +40,7 @@ Import-Package: org.apache.log4j;version="1.2.24",
  org.junit.rules;version="4.13.2",
  org.junit.runner;version="4.13.2",
  org.junit.runners.model;version="4.13.2"
-Bundle-Activator: org.eclipse.xtext.builder.tests.internal.TestsActivator
+Bundle-Activator: org.eclipse.xtext.builder.tests.internal.TestsActivatorCustom
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.xtext.builder.tests;version="2.34.0",
  org.eclipse.xtext.builder.tests.builderTestLanguage;version="2.34.0",

--- a/org.eclipse.xtext.builder.tests/plugin.xml
+++ b/org.eclipse.xtext.builder.tests/plugin.xml
@@ -19,6 +19,17 @@
 		</editor>
 	</extension>
 	<extension
+		point="org.eclipse.ui.editors">
+		<editor
+			class="org.eclipse.xtext.builder.tests.ui.BuilderTestLanguageExecutableExtensionFactoryGH2920:org.eclipse.xtext.ui.editor.XtextEditor"
+			contributorClass="org.eclipse.ui.editors.text.TextEditorActionContributor"
+			default="true"
+			extensions="buildertestlanguageGH2920"
+			id="org.eclipse.xtext.builder.tests.BuilderTestLanguage"
+			name="BuilderTestLanguage GH2920 Editor">
+		</editor>
+	</extension>
+	<extension
 		point="org.eclipse.ui.handlers">
 		<handler
 			class="org.eclipse.xtext.builder.tests.ui.BuilderTestLanguageExecutableExtensionFactory:org.eclipse.xtext.ui.editor.hyperlinking.OpenDeclarationHandler"
@@ -132,14 +143,31 @@
 			type="buildertestlanguage">
 		</parser>
 	</extension>
+	<extension
+		point="org.eclipse.emf.ecore.extension_parser">
+		<parser
+			class="org.eclipse.xtext.builder.tests.ui.BuilderTestLanguageExecutableExtensionFactoryGH2920:org.eclipse.xtext.resource.IResourceFactory"
+			type="buildertestlanguageGH2920">
+		</parser>
+	</extension>
 	<extension point="org.eclipse.xtext.extension_resourceServiceProvider">
 		<resourceServiceProvider
 			class="org.eclipse.xtext.builder.tests.ui.BuilderTestLanguageExecutableExtensionFactory:org.eclipse.xtext.ui.resource.IResourceUIServiceProvider"
 			uriExtension="buildertestlanguage">
 		</resourceServiceProvider>
 	</extension>
+	<extension point="org.eclipse.xtext.extension_resourceServiceProvider">
+		<resourceServiceProvider
+			class="org.eclipse.xtext.builder.tests.ui.BuilderTestLanguageExecutableExtensionFactoryGH2920:org.eclipse.xtext.ui.resource.IResourceUIServiceProvider"
+			uriExtension="buildertestlanguageGH2920">
+		</resourceServiceProvider>
+	</extension>
 	<extension point="org.eclipse.xtext.builder.participant">
 		<participant
 			class="org.eclipse.xtext.builder.tests.ui.BuilderTestLanguageExecutableExtensionFactory:org.eclipse.xtext.builder.IXtextBuilderParticipant"/>
+	</extension>
+	<extension point="org.eclipse.xtext.builder.participant">
+		<participant
+			class="org.eclipse.xtext.builder.tests.ui.BuilderTestLanguageExecutableExtensionFactoryGH2920:org.eclipse.xtext.builder.IXtextBuilderParticipant"/>
 	</extension>
 </plugin>

--- a/org.eclipse.xtext.builder.tests/plugin.xml
+++ b/org.eclipse.xtext.builder.tests/plugin.xml
@@ -19,17 +19,6 @@
 		</editor>
 	</extension>
 	<extension
-		point="org.eclipse.ui.editors">
-		<editor
-			class="org.eclipse.xtext.builder.tests.ui.BuilderTestLanguageExecutableExtensionFactoryGH2920:org.eclipse.xtext.ui.editor.XtextEditor"
-			contributorClass="org.eclipse.ui.editors.text.TextEditorActionContributor"
-			default="true"
-			extensions="buildertestlanguageGH2920"
-			id="org.eclipse.xtext.builder.tests.BuilderTestLanguage"
-			name="BuilderTestLanguage GH2920 Editor">
-		</editor>
-	</extension>
-	<extension
 		point="org.eclipse.ui.handlers">
 		<handler
 			class="org.eclipse.xtext.builder.tests.ui.BuilderTestLanguageExecutableExtensionFactory:org.eclipse.xtext.ui.editor.hyperlinking.OpenDeclarationHandler"

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/GH2920Test.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/impl/GH2920Test.java
@@ -20,40 +20,25 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.xtext.builder.tests.BuilderTestLanguageInjectorProvider;
-import org.eclipse.xtext.builder.tests.internal.TestsActivator;
-import org.eclipse.xtext.builder.tests.internal.TestsActivatorCustom;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.eclipse.xtext.resource.IResourceDescriptionsProvider;
-import org.eclipse.xtext.testing.InjectWith;
-import org.eclipse.xtext.testing.XtextRunner;
 import org.eclipse.xtext.ui.XtextProjectHelper;
 import org.eclipse.xtext.util.StringInputStream;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import com.google.inject.Inject;
-import com.google.inject.Injector;
 
 /**
  * @author sherrmann - Initial contribution and API
+ * @author Lorenzo Bettini - make it appropriate for reproducing https://github.com/eclipse/xtext/issues/2920
  */
-@RunWith(XtextRunner.class)
-@InjectWith(GH2920Test.BuilderTestLanguageInjectorProviderGH2920.class)
 public class GH2920Test extends AbstractParticipatingBuilderTest {
 	private IJavaProject javaProject;
 
 	@Inject private IResourceDescriptionsProvider descriptionsProvider;
 
 	private List<String> descriptionsInOutputFolder = new ArrayList<>();
-
-	public static class BuilderTestLanguageInjectorProviderGH2920 extends BuilderTestLanguageInjectorProvider {
-		@Override
-		public Injector getInjector() {
-			return TestsActivator.getInstance().getInjector(TestsActivatorCustom.ORG_ECLIPSE_XTEXT_BUILDER_TESTS_BUILDERTESTLANGUAGE_GH2920);
-		}
-	}
 
 	@Before
 	public void createProjectUnderTest() throws Exception {

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/internal/TestsActivatorCustom.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/internal/TestsActivatorCustom.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2024 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.builder.tests.internal;
+
+import org.apache.log4j.Logger;
+import org.eclipse.xtext.Constants;
+import org.eclipse.xtext.builder.tests.BuilderTestLanguageRuntimeModule;
+import org.eclipse.xtext.ui.shared.JdtHelper;
+import org.eclipse.xtext.ui.shared.SharedStateModule;
+import org.eclipse.xtext.ui.util.IJdtHelper;
+import org.eclipse.xtext.util.Modules2;
+
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Provider;
+import com.google.inject.name.Names;
+
+/**
+ * @author Lorenzo Bettini - Initial contribution and API
+ */
+public class TestsActivatorCustom extends TestsActivator {
+
+	public static final String ORG_ECLIPSE_XTEXT_BUILDER_TESTS_BUILDERTESTLANGUAGE_GH2920 = ORG_ECLIPSE_XTEXT_BUILDER_TESTS_BUILDERTESTLANGUAGE + "GH2920";
+
+	private static final Logger logger = Logger.getLogger(TestsActivatorCustom.class);
+
+	@Override
+	protected Injector createInjector(String language) {
+		if (!ORG_ECLIPSE_XTEXT_BUILDER_TESTS_BUILDERTESTLANGUAGE_GH2920.equals(language))
+			return super.createInjector(language);
+		try {
+			com.google.inject.Module runtimeModule = new BuilderTestLanguageRuntimeModule() {
+				@Override
+				public void configureFileExtensions(Binder binder) {
+					if (properties == null || properties.getProperty(Constants.FILE_EXTENSIONS) == null)
+						binder.bind(String.class).annotatedWith(Names.named(Constants.FILE_EXTENSIONS)).toInstance("buildertestlanguageGH2920");
+				}
+			};
+			com.google.inject.Module sharedStateModule = new SharedStateModule() {
+				@Override
+				public Provider<IJdtHelper> provideJdtHelper() {
+					return new Provider<>() {
+						@Override
+						public IJdtHelper get() {
+							return new JdtHelper() {
+								@Override
+								protected boolean computeJavaCoreAvailable() {
+									return false;
+								}
+							};
+						}
+					};
+				}
+			};
+			com.google.inject.Module uiModule = getUiModule(ORG_ECLIPSE_XTEXT_BUILDER_TESTS_BUILDERTESTLANGUAGE);
+			com.google.inject.Module mergedModule = Modules2.mixin(runtimeModule, sharedStateModule, uiModule);
+			return Guice.createInjector(mergedModule);
+		} catch (Exception e) {
+			logger.error("Failed to create injector for " + language);
+			logger.error(e.getMessage(), e);
+			throw new RuntimeException("Failed to create injector for " + language, e);
+		}
+	}
+
+}

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/ui/BuilderTestLanguageExecutableExtensionFactoryGH2920.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/ui/BuilderTestLanguageExecutableExtensionFactoryGH2920.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2024 itemis AG (http://www.itemis.eu) and others.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.xtext.builder.tests.ui;
+
+import org.eclipse.xtext.builder.tests.internal.TestsActivator;
+import org.eclipse.xtext.builder.tests.internal.TestsActivatorCustom;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+
+import com.google.inject.Injector;
+
+/**
+ * @author Lorenzo Bettini - Initial contribution and API
+ */
+public class BuilderTestLanguageExecutableExtensionFactoryGH2920 extends BuilderTestLanguageExecutableExtensionFactory {
+
+	@Override
+	protected Bundle getBundle() {
+		return FrameworkUtil.getBundle(TestsActivatorCustom.class);
+	}
+
+	@Override
+	protected Injector getInjector() {
+		TestsActivator activator = TestsActivator.getInstance();
+		return activator != null ? activator.getInjector(TestsActivatorCustom.ORG_ECLIPSE_XTEXT_BUILDER_TESTS_BUILDERTESTLANGUAGE_GH2920) : null;
+	}
+}

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/ui/BuilderTestLanguageExecutableExtensionFactoryGH2920.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/ui/BuilderTestLanguageExecutableExtensionFactoryGH2920.java
@@ -10,8 +10,6 @@ package org.eclipse.xtext.builder.tests.ui;
 
 import org.eclipse.xtext.builder.tests.internal.TestsActivator;
 import org.eclipse.xtext.builder.tests.internal.TestsActivatorCustom;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.FrameworkUtil;
 
 import com.google.inject.Injector;
 
@@ -19,11 +17,6 @@ import com.google.inject.Injector;
  * @author Lorenzo Bettini - Initial contribution and API
  */
 public class BuilderTestLanguageExecutableExtensionFactoryGH2920 extends BuilderTestLanguageExecutableExtensionFactory {
-
-	@Override
-	protected Bundle getBundle() {
-		return FrameworkUtil.getBundle(TestsActivatorCustom.class);
-	}
 
 	@Override
 	protected Injector getInjector() {

--- a/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/ui/BuilderTestLanguageExecutableExtensionFactoryGH2920.java
+++ b/org.eclipse.xtext.builder.tests/src/org/eclipse/xtext/builder/tests/ui/BuilderTestLanguageExecutableExtensionFactoryGH2920.java
@@ -14,6 +14,8 @@ import org.eclipse.xtext.builder.tests.internal.TestsActivatorCustom;
 import com.google.inject.Injector;
 
 /**
+ * This allows customizations in the UI, specific for some test scenarions, without creating new languages.
+ * 
  * @author Lorenzo Bettini - Initial contribution and API
  */
 public class BuilderTestLanguageExecutableExtensionFactoryGH2920 extends BuilderTestLanguageExecutableExtensionFactory {
@@ -21,6 +23,7 @@ public class BuilderTestLanguageExecutableExtensionFactoryGH2920 extends Builder
 	@Override
 	protected Injector getInjector() {
 		TestsActivator activator = TestsActivator.getInstance();
-		return activator != null ? activator.getInjector(TestsActivatorCustom.ORG_ECLIPSE_XTEXT_BUILDER_TESTS_BUILDERTESTLANGUAGE_GH2920) : null;
+		return activator != null ? activator.getInjector(TestsActivatorCustom.ORG_ECLIPSE_XTEXT_BUILDER_TESTS_BUILDERTESTLANGUAGE_GH2920)
+				: null;
 	}
 }


### PR DESCRIPTION
This PR fixes the original test of https://github.com/eclipse/xtext/pull/2921 to effectively recreate the original problem of https://github.com/eclipse/xtext/issues/2920

I mean that, **without** the patched `XtextBuilder` the test **fails**, **with** the patched `XtextBuilder` it **succeeds**.

The idea is to create a fictitious additional language extension, `buildertestlanguageGH2920`, and add some extension points in plugin.xml for this language extension, by using a custom executable extension factory and introducing a new customizable activator that, for this "language", redefines the creation of `JdtHelper` to always return false when asked whether `isJavaCoreAvailable`.

@stephan-herrmann note that I also slightly modify the way the assertions are performed: in your original test the assertions were made during the build. When they fail, the test ends with an error just saying that the build has failed (this is due to the AssertionError being wrapped in a CoreException being wrapped in a OperationCancelledException). The assertion failure is only printed on the console. This makes it hard to understand it. Now, the possible offending resource descriptions are only collected during the build, and the assertions are made outside the build. This way, when the test fails we get a proper failure message.

@szarnekow I hope this solution makes sense, it took me some time to understand how to inject these customizations only for this test :) 